### PR TITLE
Do not even add the testing executables when the tests are disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(boost)
 
+option(BUILD_TESTING "Build the test suite" OFF)
+
 macro(find_package NAME)
     if(NOT "${NAME}" MATCHES "^boost_.*$" AND NOT "${NAME}" STREQUAL BCM)
         _find_package(${ARGV})

--- a/bcm/CMakeLists.txt
+++ b/bcm/CMakeLists.txt
@@ -4,4 +4,4 @@ install(DIRECTORY share DESTINATION .)
 
 enable_testing()
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/bcm/share/bcm/cmake/BCMTest.cmake
+++ b/bcm/share/bcm/cmake/BCMTest.cmake
@@ -82,6 +82,9 @@ endfunction()
 
 
 function(bcm_test)
+    if(NOT BUILD_TESTING)
+        return()
+    endif()
     set(options COMPILE_ONLY WILL_FAIL NO_TEST_LIBS)
     set(oneValueArgs NAME)
     set(multiValueArgs SOURCES CONTENT ARGS)
@@ -156,3 +159,10 @@ function(bcm_test_header)
         bcm_target_link_test_libs(${PARSE_NAME})
     endif()
 endfunction(bcm_test_header)
+
+
+function(bcm_add_test_subdirectory)
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
+endfunction()

--- a/libs/accumulators/CMakeLists.txt
+++ b/libs/accumulators/CMakeLists.txt
@@ -4,6 +4,7 @@ project(boost_accumulators)
 find_package(BCM)
 include(BCMDeploy)
 include(BCMSetupVersion)
+include(BCMTest)
 
 find_package(boost_core)
 find_package(boost_static_assert)
@@ -56,4 +57,4 @@ target_link_libraries(boost_accumulators INTERFACE boost::typeof)
 
 bcm_deploy(TARGETS boost_accumulators INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/algorithm/CMakeLists.txt
+++ b/libs/algorithm/CMakeLists.txt
@@ -52,4 +52,4 @@ target_link_libraries(boost_algorithm INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_algorithm INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/align/CMakeLists.txt
+++ b/libs/align/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_align INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_align INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/any/CMakeLists.txt
+++ b/libs/any/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_any INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_any INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/array/CMakeLists.txt
+++ b/libs/array/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_array INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_array INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/asio/CMakeLists.txt
+++ b/libs/asio/CMakeLists.txt
@@ -54,4 +54,4 @@ endif()
 
 bcm_deploy(TARGETS boost_asio INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/assert/CMakeLists.txt
+++ b/libs/assert/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(boost_assert INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_assert INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/assign/CMakeLists.txt
+++ b/libs/assign/CMakeLists.txt
@@ -36,4 +36,4 @@ target_link_libraries(boost_assign INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_assign INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/atomic/CMakeLists.txt
+++ b/libs/atomic/CMakeLists.txt
@@ -26,4 +26,4 @@ target_include_directories(boost_atomic PRIVATE include)
 
 bcm_deploy(TARGETS boost_atomic INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/beast/CMakeLists.txt
+++ b/libs/beast/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_beast PROPERTY EXPORT_NAME beast)
 
 bcm_deploy(TARGETS boost_beast INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/bimap/CMakeLists.txt
+++ b/libs/bimap/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(boost_bimap INTERFACE boost::lambda)
 
 bcm_deploy(TARGETS boost_bimap INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/bind/CMakeLists.txt
+++ b/libs/bind/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_bind INTERFACE boost::core)
 
 bcm_deploy(TARGETS boost_bind INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/callable_traits/CMakeLists.txt
+++ b/libs/callable_traits/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_callable_traits PROPERTY EXPORT_NAME callable_traits)
 
 bcm_deploy(TARGETS boost_callable_traits INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/chrono/CMakeLists.txt
+++ b/libs/chrono/CMakeLists.txt
@@ -52,4 +52,4 @@ target_include_directories(boost_chrono PRIVATE include)
 
 bcm_deploy(TARGETS boost_chrono INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/circular_buffer/CMakeLists.txt
+++ b/libs/circular_buffer/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(boost_circular_buffer INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_circular_buffer INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/compatibility/CMakeLists.txt
+++ b/libs/compatibility/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_compatibility PROPERTY EXPORT_NAME compatibility)
 
 bcm_deploy(TARGETS boost_compatibility INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/compute/CMakeLists.txt
+++ b/libs/compute/CMakeLists.txt
@@ -72,4 +72,4 @@ target_link_libraries(boost_compute INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_compute INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/concept_check/CMakeLists.txt
+++ b/libs/concept_check/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_concept_check INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_concept_check INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/config/CMakeLists.txt
+++ b/libs/config/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_config PROPERTY EXPORT_NAME config)
 
 bcm_deploy(TARGETS boost_config INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/container/CMakeLists.txt
+++ b/libs/container/CMakeLists.txt
@@ -41,4 +41,4 @@ target_include_directories(boost_container PRIVATE include)
 
 bcm_deploy(TARGETS boost_container INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/context/CMakeLists.txt
+++ b/libs/context/CMakeLists.txt
@@ -139,4 +139,4 @@ target_include_directories(boost_context PRIVATE include)
 
 bcm_deploy(TARGETS boost_context INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/conversion/CMakeLists.txt
+++ b/libs/conversion/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_conversion INTERFACE boost::smart_ptr)
 
 bcm_deploy(TARGETS boost_conversion INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/convert/CMakeLists.txt
+++ b/libs/convert/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(boost_convert INTERFACE boost::math)
 
 bcm_deploy(TARGETS boost_convert INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_core INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_core INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/coroutine/CMakeLists.txt
+++ b/libs/coroutine/CMakeLists.txt
@@ -50,4 +50,4 @@ target_include_directories(boost_coroutine PRIVATE include)
 
 bcm_deploy(TARGETS boost_coroutine INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/coroutine2/CMakeLists.txt
+++ b/libs/coroutine2/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(boost_coroutine2 INTERFACE boost::context)
 
 bcm_deploy(TARGETS boost_coroutine2 INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/crc/CMakeLists.txt
+++ b/libs/crc/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_crc INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_crc INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/date_time/CMakeLists.txt
+++ b/libs/date_time/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(boost_date_time PUBLIC boost::utility)
 
 bcm_deploy(TARGETS boost_date_time INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/detail/CMakeLists.txt
+++ b/libs/detail/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_detail INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_detail INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/disjoint_sets/CMakeLists.txt
+++ b/libs/disjoint_sets/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(boost_disjoint_sets INTERFACE boost::graph)
 
 bcm_deploy(TARGETS boost_disjoint_sets INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/dll/CMakeLists.txt
+++ b/libs/dll/CMakeLists.txt
@@ -50,4 +50,4 @@ endif()
 
 bcm_deploy(TARGETS boost_dll INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/dynamic_bitset/CMakeLists.txt
+++ b/libs/dynamic_bitset/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_dynamic_bitset INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_dynamic_bitset INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/endian/CMakeLists.txt
+++ b/libs/endian/CMakeLists.txt
@@ -34,4 +34,4 @@ target_link_libraries(boost_endian INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_endian INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/exception/CMakeLists.txt
+++ b/libs/exception/CMakeLists.txt
@@ -32,4 +32,4 @@ target_include_directories(boost_exception PRIVATE include)
 
 bcm_deploy(TARGETS boost_exception INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/fiber/CMakeLists.txt
+++ b/libs/fiber/CMakeLists.txt
@@ -42,4 +42,4 @@ target_include_directories(boost_fiber PRIVATE include)
 
 bcm_deploy(TARGETS boost_fiber INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/filesystem/CMakeLists.txt
+++ b/libs/filesystem/CMakeLists.txt
@@ -51,4 +51,4 @@ target_include_directories(boost_filesystem PRIVATE include)
 
 bcm_deploy(TARGETS boost_filesystem INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/flyweight/CMakeLists.txt
+++ b/libs/flyweight/CMakeLists.txt
@@ -46,4 +46,4 @@ target_link_libraries(boost_flyweight INTERFACE boost::smart_ptr)
 
 bcm_deploy(TARGETS boost_flyweight INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/foreach/CMakeLists.txt
+++ b/libs/foreach/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_foreach INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_foreach INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/format/CMakeLists.txt
+++ b/libs/format/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_format INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_format INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/function/CMakeLists.txt
+++ b/libs/function/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(boost_function INTERFACE boost::typeof)
 
 bcm_deploy(TARGETS boost_function INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/function_types/CMakeLists.txt
+++ b/libs/function_types/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_function_types INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_function_types INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/functional/CMakeLists.txt
+++ b/libs/functional/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(boost_functional INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_functional INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/fusion/CMakeLists.txt
+++ b/libs/fusion/CMakeLists.txt
@@ -40,4 +40,4 @@ target_link_libraries(boost_fusion INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_fusion INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/geometry/CMakeLists.txt
+++ b/libs/geometry/CMakeLists.txt
@@ -78,4 +78,4 @@ target_link_libraries(boost_geometry INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_geometry INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/gil/CMakeLists.txt
+++ b/libs/gil/CMakeLists.txt
@@ -38,4 +38,4 @@ target_link_libraries(boost_gil INTERFACE boost::preprocessor)
 
 bcm_deploy(TARGETS boost_gil INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/graph/CMakeLists.txt
+++ b/libs/graph/CMakeLists.txt
@@ -105,4 +105,4 @@ target_include_directories(boost_graph PRIVATE include)
 
 bcm_deploy(TARGETS boost_graph INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/hana/CMakeLists.txt
+++ b/libs/hana/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_hana INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_hana INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/heap/CMakeLists.txt
+++ b/libs/heap/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(boost_heap INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_heap INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/icl/CMakeLists.txt
+++ b/libs/icl/CMakeLists.txt
@@ -46,4 +46,4 @@ target_link_libraries(boost_icl INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_icl INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/integer/CMakeLists.txt
+++ b/libs/integer/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_integer INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_integer INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/interprocess/CMakeLists.txt
+++ b/libs/interprocess/CMakeLists.txt
@@ -48,4 +48,4 @@ endif()
 
 bcm_deploy(TARGETS boost_interprocess INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/intrusive/CMakeLists.txt
+++ b/libs/intrusive/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_intrusive INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_intrusive INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/io/CMakeLists.txt
+++ b/libs/io/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(boost_io INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_io INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/iostreams/CMakeLists.txt
+++ b/libs/iostreams/CMakeLists.txt
@@ -68,4 +68,4 @@ target_include_directories(boost_iostreams PRIVATE include)
 
 bcm_deploy(TARGETS boost_iostreams INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/iterator/CMakeLists.txt
+++ b/libs/iterator/CMakeLists.txt
@@ -46,4 +46,4 @@ target_link_libraries(boost_iterator INTERFACE boost::conversion)
 
 bcm_deploy(TARGETS boost_iterator INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/lambda/CMakeLists.txt
+++ b/libs/lambda/CMakeLists.txt
@@ -38,4 +38,4 @@ target_link_libraries(boost_lambda INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_lambda INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/lexical_cast/CMakeLists.txt
+++ b/libs/lexical_cast/CMakeLists.txt
@@ -44,4 +44,4 @@ target_link_libraries(boost_lexical_cast INTERFACE boost::math)
 
 bcm_deploy(TARGETS boost_lexical_cast INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/local_function/CMakeLists.txt
+++ b/libs/local_function/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_local_function INTERFACE boost::preprocessor)
 
 bcm_deploy(TARGETS boost_local_function INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/locale/CMakeLists.txt
+++ b/libs/locale/CMakeLists.txt
@@ -111,4 +111,4 @@ target_link_libraries(boost_locale PUBLIC boost::unordered)
 
 bcm_deploy(TARGETS boost_locale INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/lockfree/CMakeLists.txt
+++ b/libs/lockfree/CMakeLists.txt
@@ -46,4 +46,4 @@ target_link_libraries(boost_lockfree INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_lockfree INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/log/CMakeLists.txt
+++ b/libs/log/CMakeLists.txt
@@ -248,4 +248,4 @@ target_include_directories(boost_log PRIVATE include)
 
 bcm_deploy(TARGETS boost_log INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/logic/CMakeLists.txt
+++ b/libs/logic/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_logic INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_logic INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/math/CMakeLists.txt
+++ b/libs/math/CMakeLists.txt
@@ -129,4 +129,4 @@ endif()
 
 bcm_deploy(TARGETS boost_math boost_math_c99 boost_math_c99f boost_math_c99l boost_math_tr1 boost_math_tr1f boost_math_tr1l INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/metaparse/CMakeLists.txt
+++ b/libs/metaparse/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_metaparse INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_metaparse INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/move/CMakeLists.txt
+++ b/libs/move/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(boost_move INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_move INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/mp11/CMakeLists.txt
+++ b/libs/mp11/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_mp11 PROPERTY EXPORT_NAME mp11)
 
 bcm_deploy(TARGETS boost_mp11 INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/mpl/CMakeLists.txt
+++ b/libs/mpl/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_mpl INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_mpl INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/msm/CMakeLists.txt
+++ b/libs/msm/CMakeLists.txt
@@ -52,4 +52,4 @@ target_link_libraries(boost_msm INTERFACE boost::typeof)
 
 bcm_deploy(TARGETS boost_msm INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/multi_array/CMakeLists.txt
+++ b/libs/multi_array/CMakeLists.txt
@@ -38,4 +38,4 @@ target_link_libraries(boost_multi_array INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_multi_array INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/multi_index/CMakeLists.txt
+++ b/libs/multi_index/CMakeLists.txt
@@ -56,4 +56,4 @@ target_link_libraries(boost_multi_index INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_multi_index INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/multiprecision/CMakeLists.txt
+++ b/libs/multiprecision/CMakeLists.txt
@@ -50,4 +50,4 @@ target_link_libraries(boost_multiprecision INTERFACE boost::math)
 
 bcm_deploy(TARGETS boost_multiprecision INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/numeric/conversion/CMakeLists.txt
+++ b/libs/numeric/conversion/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_numeric_conversion INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_numeric_conversion INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/numeric/interval/CMakeLists.txt
+++ b/libs/numeric/interval/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(boost_numeric_interval INTERFACE boost::detail)
 
 bcm_deploy(TARGETS boost_numeric_interval INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/numeric/odeint/CMakeLists.txt
+++ b/libs/numeric/odeint/CMakeLists.txt
@@ -58,4 +58,4 @@ target_link_libraries(boost_numeric_odeint INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_numeric_odeint INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/numeric/ublas/CMakeLists.txt
+++ b/libs/numeric/ublas/CMakeLists.txt
@@ -44,4 +44,4 @@ target_link_libraries(boost_numeric_ublas INTERFACE boost::smart_ptr)
 
 bcm_deploy(TARGETS boost_numeric_ublas INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/optional/CMakeLists.txt
+++ b/libs/optional/CMakeLists.txt
@@ -38,4 +38,4 @@ target_link_libraries(boost_optional INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_optional INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/parameter/CMakeLists.txt
+++ b/libs/parameter/CMakeLists.txt
@@ -36,4 +36,4 @@ target_link_libraries(boost_parameter INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_parameter INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/phoenix/CMakeLists.txt
+++ b/libs/phoenix/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(boost_phoenix INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_phoenix INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/poly_collection/CMakeLists.txt
+++ b/libs/poly_collection/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_poly_collection PROPERTY EXPORT_NAME poly_collection)
 
 bcm_deploy(TARGETS boost_poly_collection INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/polygon/CMakeLists.txt
+++ b/libs/polygon/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(boost_polygon INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_polygon INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/pool/CMakeLists.txt
+++ b/libs/pool/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(boost_pool INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_pool INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/predef/CMakeLists.txt
+++ b/libs/predef/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_predef PROPERTY EXPORT_NAME predef)
 
 bcm_deploy(TARGETS boost_predef INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/preprocessor/CMakeLists.txt
+++ b/libs/preprocessor/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_preprocessor PROPERTY EXPORT_NAME preprocessor)
 
 bcm_deploy(TARGETS boost_preprocessor INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/process/CMakeLists.txt
+++ b/libs/process/CMakeLists.txt
@@ -44,4 +44,4 @@ target_link_libraries(boost_process INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_process INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/program_options/CMakeLists.txt
+++ b/libs/program_options/CMakeLists.txt
@@ -56,4 +56,4 @@ target_include_directories(boost_program_options PRIVATE include)
 
 bcm_deploy(TARGETS boost_program_options INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/property_map/CMakeLists.txt
+++ b/libs/property_map/CMakeLists.txt
@@ -54,4 +54,4 @@ target_link_libraries(boost_property_map INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_property_map INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/property_tree/CMakeLists.txt
+++ b/libs/property_tree/CMakeLists.txt
@@ -50,4 +50,4 @@ target_link_libraries(boost_property_tree INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_property_tree INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/proto/CMakeLists.txt
+++ b/libs/proto/CMakeLists.txt
@@ -38,4 +38,4 @@ target_link_libraries(boost_proto INTERFACE boost::typeof)
 
 bcm_deploy(TARGETS boost_proto INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/ptr_container/CMakeLists.txt
+++ b/libs/ptr_container/CMakeLists.txt
@@ -46,4 +46,4 @@ target_link_libraries(boost_ptr_container INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_ptr_container INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/python/CMakeLists.txt
+++ b/libs/python/CMakeLists.txt
@@ -99,4 +99,4 @@ target_include_directories(boost_python PRIVATE include)
 
 bcm_deploy(TARGETS boost_python INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/qvm/CMakeLists.txt
+++ b/libs/qvm/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_qvm INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_qvm INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/random/CMakeLists.txt
+++ b/libs/random/CMakeLists.txt
@@ -44,4 +44,4 @@ target_include_directories(boost_random PRIVATE include)
 
 bcm_deploy(TARGETS boost_random INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/range/CMakeLists.txt
+++ b/libs/range/CMakeLists.txt
@@ -52,4 +52,4 @@ target_link_libraries(boost_range INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_range INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/ratio/CMakeLists.txt
+++ b/libs/ratio/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_ratio INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_ratio INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/rational/CMakeLists.txt
+++ b/libs/rational/CMakeLists.txt
@@ -34,4 +34,4 @@ target_link_libraries(boost_rational INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_rational INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/regex/CMakeLists.txt
+++ b/libs/regex/CMakeLists.txt
@@ -62,4 +62,4 @@ target_include_directories(boost_regex PRIVATE include)
 
 bcm_deploy(TARGETS boost_regex INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/scope_exit/CMakeLists.txt
+++ b/libs/scope_exit/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_scope_exit INTERFACE boost::preprocessor)
 
 bcm_deploy(TARGETS boost_scope_exit INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/serialization/CMakeLists.txt
+++ b/libs/serialization/CMakeLists.txt
@@ -100,4 +100,4 @@ target_include_directories(boost_serialization PRIVATE include)
 
 bcm_deploy(TARGETS boost_serialization INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/signals/CMakeLists.txt
+++ b/libs/signals/CMakeLists.txt
@@ -44,4 +44,4 @@ target_include_directories(boost_signals PRIVATE include)
 
 bcm_deploy(TARGETS boost_signals INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/signals2/CMakeLists.txt
+++ b/libs/signals2/CMakeLists.txt
@@ -52,4 +52,4 @@ target_link_libraries(boost_signals2 INTERFACE boost::smart_ptr)
 
 bcm_deploy(TARGETS boost_signals2 INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/smart_ptr/CMakeLists.txt
+++ b/libs/smart_ptr/CMakeLists.txt
@@ -34,4 +34,4 @@ target_link_libraries(boost_smart_ptr INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_smart_ptr INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/sort/CMakeLists.txt
+++ b/libs/sort/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_sort INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_sort INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/spirit/CMakeLists.txt
+++ b/libs/spirit/CMakeLists.txt
@@ -96,4 +96,4 @@ target_link_libraries(boost_spirit INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_spirit INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/stacktrace/CMakeLists.txt
+++ b/libs/stacktrace/CMakeLists.txt
@@ -18,4 +18,4 @@ set_property(TARGET boost_stacktrace PROPERTY EXPORT_NAME stacktrace)
 
 bcm_deploy(TARGETS boost_stacktrace INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/statechart/CMakeLists.txt
+++ b/libs/statechart/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(boost_statechart INTERFACE boost::conversion)
 
 bcm_deploy(TARGETS boost_statechart INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/static_assert/CMakeLists.txt
+++ b/libs/static_assert/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(boost_static_assert INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_static_assert INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/system/CMakeLists.txt
+++ b/libs/system/CMakeLists.txt
@@ -28,4 +28,4 @@ target_include_directories(boost_system PRIVATE include)
 
 bcm_deploy(TARGETS boost_system INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/test/CMakeLists.txt
+++ b/libs/test/CMakeLists.txt
@@ -126,4 +126,4 @@ bcm_shadow_notify(boost::test)
 
 bcm_deploy(TARGETS boost_prg_exec_monitor boost_test_exec_monitor boost_unit_test_framework INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/thread/CMakeLists.txt
+++ b/libs/thread/CMakeLists.txt
@@ -94,4 +94,4 @@ target_include_directories(boost_thread PRIVATE include)
 
 bcm_deploy(TARGETS boost_thread INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/throw_exception/CMakeLists.txt
+++ b/libs/throw_exception/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_throw_exception INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_throw_exception INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/timer/CMakeLists.txt
+++ b/libs/timer/CMakeLists.txt
@@ -33,4 +33,4 @@ target_include_directories(boost_timer PRIVATE include)
 
 bcm_deploy(TARGETS boost_timer INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/tokenizer/CMakeLists.txt
+++ b/libs/tokenizer/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_tokenizer INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_tokenizer INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/tr1/CMakeLists.txt
+++ b/libs/tr1/CMakeLists.txt
@@ -56,4 +56,4 @@ target_link_libraries(boost_tr1 INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_tr1 INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/tti/CMakeLists.txt
+++ b/libs/tti/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_tti INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_tti INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/tuple/CMakeLists.txt
+++ b/libs/tuple/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(boost_tuple INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_tuple INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/type_erasure/CMakeLists.txt
+++ b/libs/type_erasure/CMakeLists.txt
@@ -44,4 +44,4 @@ target_include_directories(boost_type_erasure PRIVATE include)
 
 bcm_deploy(TARGETS boost_type_erasure INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/type_index/CMakeLists.txt
+++ b/libs/type_index/CMakeLists.txt
@@ -34,4 +34,4 @@ target_link_libraries(boost_type_index INTERFACE boost::preprocessor)
 
 bcm_deploy(TARGETS boost_type_index INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/type_traits/CMakeLists.txt
+++ b/libs/type_traits/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(boost_type_traits INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_type_traits INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/typeof/CMakeLists.txt
+++ b/libs/typeof/CMakeLists.txt
@@ -28,4 +28,4 @@ target_link_libraries(boost_typeof INTERFACE boost::config)
 
 bcm_deploy(TARGETS boost_typeof INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/units/CMakeLists.txt
+++ b/libs/units/CMakeLists.txt
@@ -44,4 +44,4 @@ target_link_libraries(boost_units INTERFACE boost::lambda)
 
 bcm_deploy(TARGETS boost_units INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/unordered/CMakeLists.txt
+++ b/libs/unordered/CMakeLists.txt
@@ -44,4 +44,4 @@ target_link_libraries(boost_unordered INTERFACE boost::smart_ptr)
 
 bcm_deploy(TARGETS boost_unordered INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/utility/CMakeLists.txt
+++ b/libs/utility/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(boost_utility INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_utility INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/uuid/CMakeLists.txt
+++ b/libs/uuid/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(boost_uuid INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_uuid INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/variant/CMakeLists.txt
+++ b/libs/variant/CMakeLists.txt
@@ -48,4 +48,4 @@ target_link_libraries(boost_variant INTERFACE boost::utility)
 
 bcm_deploy(TARGETS boost_variant INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/vmd/CMakeLists.txt
+++ b/libs/vmd/CMakeLists.txt
@@ -20,4 +20,4 @@ target_link_libraries(boost_vmd INTERFACE boost::preprocessor)
 
 bcm_deploy(TARGETS boost_vmd INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/wave/CMakeLists.txt
+++ b/libs/wave/CMakeLists.txt
@@ -60,4 +60,4 @@ target_include_directories(boost_wave PRIVATE include)
 
 bcm_deploy(TARGETS boost_wave INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/winapi/CMakeLists.txt
+++ b/libs/winapi/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(boost_winapi INTERFACE boost::predef)
 
 bcm_deploy(TARGETS boost_winapi INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()

--- a/libs/xpressive/CMakeLists.txt
+++ b/libs/xpressive/CMakeLists.txt
@@ -60,4 +60,4 @@ target_link_libraries(boost_xpressive INTERFACE boost::throw_exception)
 
 bcm_deploy(TARGETS boost_xpressive INCLUDE include NAMESPACE boost::)
 
-add_subdirectory(test)
+bcm_add_test_subdirectory()


### PR DESCRIPTION
The tests are currently targets excluded by the default target, so they aren't built.

But excluded targets are still generated, and created.

This has two results:

* For IDE projects (like the visual studio generators), each test executable is added as a project, resulting in a long list. This is especially bad if you want to add boost-cmake using ADD_SUBDIRECTORY to your project: you most likely do not want to see those tests there. Maybe you want them on your CI, but definitely not during development.
* These tests are also the reason why the "configure" phase of CMake takes minutes: by removing them, I reduced the project generation time of CMake to only a few seconds.

I simply reused the `BUILD_TESTING` option to not even include the test directories if it's not set. As you also used the off setting for some different behavior, I do not think this will be the correct/final solutions to it, but I do think that an option to disable them (and making that a default) would make the project more usable for end users.