### PR TITLE
Added .cpp files in the algo subfolder to the add_library command in CMakeLists.txt for Fiber

### DIFF
--- a/libs/fiber/CMakeLists.txt
+++ b/libs/fiber/CMakeLists.txt
@@ -26,6 +26,10 @@ src/recursive_timed_mutex.cpp
 src/recursive_mutex.cpp
 src/fiber.cpp
 src/context.cpp
+src/algo/algorithm.cpp
+src/algo/round_robin.cpp
+src/algo/shared_work.cpp
+src/algo/work_stealing.cpp
 )
 set_property(TARGET boost_fiber PROPERTY EXPORT_NAME fiber)
 


### PR DESCRIPTION
After building Fiber successfully, I attempted to use it from my project and linking failed with the cryptic error, "undefined reference to vtable" in the constructor for the round_robin class.

A little searching on google led me to this issue on Stack Overflow... https://stackoverflow.com/questions/3065154/undefined-reference-to-vtable.

After reviewing the CMakeLists.txt file and the structure of the src folder, I found that the .cpp files in the algo subfolder of src were not included in the add_library command in the CMakeLists.txt file.

I made a very small change to add them to the add_library command in the CMakeLists.txt file.  I tested the change on Windows 10, cross compiling to the Magic Leap (an Android variant) and the error was resolved.  This has had minimal testing but it looks pretty clear that the missing files were the issue and the fix was very simple.